### PR TITLE
rewritten class ArabicToRomanParser

### DIFF
--- a/src/main/java/com/hukuta94/simplecalculator/input/Validator.java
+++ b/src/main/java/com/hukuta94/simplecalculator/input/Validator.java
@@ -4,8 +4,7 @@ import com.hukuta94.simplecalculator.model.Data;
 import com.hukuta94.simplecalculator.model.NumberType;
 import com.hukuta94.simplecalculator.model.RomanNumeral;
 
-abstract class Validator
-{
+public class Validator {
     private static final int MIN_NUMBER = 1;
     private static final int MAX_NUMBER = 10;
     private static final String ROMAN_NUMBERS = "IVXLCM";

--- a/src/main/java/com/hukuta94/simplecalculator/model/RomanNumeral.java
+++ b/src/main/java/com/hukuta94/simplecalculator/model/RomanNumeral.java
@@ -31,7 +31,8 @@ public enum RomanNumeral
     CM( "CM", 900 ),
     M( "M", 1000 ),
     MM( "MM", 2000 ),
-    MMM( "MMM", 3000 );
+    MMM( "MMM", 3000 ),
+    o ("", 0);
 
 
     private String roman;

--- a/src/main/java/com/hukuta94/simplecalculator/parser/ArabicToRomanParser.java
+++ b/src/main/java/com/hukuta94/simplecalculator/parser/ArabicToRomanParser.java
@@ -1,21 +1,15 @@
 package com.hukuta94.simplecalculator.parser;
 
-public abstract class ArabicToRomanParser
-{
-    private static final String[] THOUSANDS = { "", "M", "MM", "MMM" };
-    private static final String[] HUNDREDS = { "", "C", "CC", "CCC", "CD", "D", "DC", "DCC", "DCCC", "CM" };
-    private static final String[] TENS = { "", "X", "XX", "XXX", "XL", "L", "LX", "LXX", "LXXX", "XC" };
-    private static final String[] UNITS = { "", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX" };
+import com.hukuta94.simplecalculator.model.RomanNumeral;
 
-    public static String parse( int number )
-    {
-        StringBuilder roman = new StringBuilder();
+public abstract class ArabicToRomanParser {
 
-        roman.append( THOUSANDS[ (number/1000) % 10 ])
-             .append( HUNDREDS[ (number/100) % 10 ])
-             .append( TENS[ (number/10) % 10 ])
-             .append( UNITS[ number% 10 ]);
+    public static String parse( int number ) {
+        String THOUSANDS = RomanNumeral.toRoman((number/1000) * 1000);
+        String HUNDREDS = RomanNumeral.toRoman(((number/100) % 10) * 100);
+        String TENS = RomanNumeral.toRoman(((number/10) % 10) * 10);
+        String UNITS = RomanNumeral.toRoman(number % 10);
 
-        return roman.toString();
+        return THOUSANDS + HUNDREDS + TENS + UNITS;
     }
 }


### PR DESCRIPTION
Переписал класс ArabicToRomanParser. Вместо объявленных в нем констант, дублирующих RomanNumeral, теперь используется сам RomanNumeral. Чтобы это стало возможным, пришлось добавить в RomanNumeral элемент "ноль".